### PR TITLE
Bugfix for PrusaSlicer issue 4

### DIFF
--- a/Prusaslicer/Fuzzyficator_Prusaslicer.py
+++ b/Prusaslicer/Fuzzyficator_Prusaslicer.py
@@ -167,7 +167,13 @@ if __name__ == "__main__":
                 new_gcode.append(line)
             elif line.startswith(';LAYER:'):
                 new_gcode.append(line)
-            elif 'G1' in line and 'Z' in line:
+                
+            elif in_top_solid_infill and line.startswith('G1') and 'X' in line and 'Y' in line and not 'E' in line and not 'Z' in line:
+                logging.info("Processed a travel move")
+                previous_point = None  # Reset previous point at the start of a new top solid infill section
+                new_gcode.append(line)
+                
+            elif 'G1' in line and 'Z' in line and not 'X' in line:
                 # Update the current layer height based on the Z value in the G1 command
                 z_match = re.search(r'Z([-+]?[0-9]*\.?[0-9]+)', line)
                 if z_match:


### PR DESCRIPTION
For PrusaSlicer, changes made to new rows 170-176 to address issue 4. This prevents modification of travel moves by the script. Was tested on PrusaSlicer-2.8.1 with RepRap/Sprinter G-code flavor.

![Output Example](https://github.com/user-attachments/assets/698af0fe-e1f0-4224-8cc6-d8fd8dc18fbf)
