### PR TITLE
Fuzzy travel moves fix

### DIFF
--- a/Fuzzyficator.py
+++ b/Fuzzyficator.py
@@ -283,7 +283,7 @@ class GCodeProcessor:
             return self.handle_top_solid_infill(line)
         elif line.startswith(self.lookup["type"]):
             return self.handle_type_change(line)
-        elif 'G1' in line and 'Z' in line:
+        elif 'G1' in line and 'Z' in line and not 'X' in lin and not 'Y' in line:
             return self.handle_z_movement(line)
         elif (self.in_top_solid_infill or (self.in_bridge and self.config.lower_surface)) and line.startswith('G1'):
             return self.handle_movement_in_infill(line)
@@ -411,3 +411,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/Fuzzyficator_paintOn.py
+++ b/Fuzzyficator_paintOn.py
@@ -391,7 +391,7 @@ class GCodeProcessor:
             return self.handle_type_change(line)
         
         # Handle Z movements
-        elif 'G1' in line and 'Z' in line:
+        elif 'G1' in line and 'Z' in line and not 'X' in line and not 'Y' in line:
             return self.handle_z_movement(line)
         
         # Handle movement commands based on current section
@@ -840,3 +840,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/Fuzzyficator_pattern.py
+++ b/Fuzzyficator_pattern.py
@@ -702,7 +702,7 @@ class GCodeProcessor:
             return self.handle_type_change(line)
         
         # Handle Z movements
-        elif 'G1' in line and 'Z' in line:
+        elif 'G1' in line and 'Z' in line and not 'X' in line and not 'Y' in line:
             return self.handle_z_movement(line)
         
         # Handle movement commands based on current section
@@ -1170,3 +1170,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
A minor fix to remove these strings that appear where there should be travel moves. Here's small section of the part I was working on when I found the root of the issue.

Before:
<img width="1096" height="217" alt="image" src="https://github.com/user-attachments/assets/46f8ac86-d8ad-4322-b901-5b6266b1484f" />

After:
<img width="1096" height="217" alt="image" src="https://github.com/user-attachments/assets/46856ea7-438c-4b95-a2d4-f1deefa69983" />

The code that caused this was the if statement that sent gcode to `handle_z_movement`. This line (`elif 'G1' in line and 'Z' in line:` or the equivalents in other scripts) consumed all G1 commands that contained a Z coordinate. This may seems like a fair assumption, but Orca Slicer at least likes to put lines like "G1 X20 Y40 Z10" for travel moves between layers. 

This leads the script to improperly handle those lines as merely Z movement. This causes the value `previous_point` to still have the value for the previous layer. If the layer change travel move goes between two sections of the part, a string will be created where the travel move should've been.

I am willing to do any requested testing or refactoring to get this merged in.